### PR TITLE
Missing " / "and "fastcgi_param SCRIPT_FILENAME $request_filename;"

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,4 +1,4 @@
-location YNH_WWW_PATH {
+location YNH_WWW_PATH / {
 
   # Path to source
   alias YNH_WWW_ALIAS/ ;
@@ -18,6 +18,7 @@ location YNH_WWW_PATH {
     include fastcgi_params;
     fastcgi_param   REMOTE_USER   $remote_user;
     fastcgi_param  PATH_INFO $fastcgi_path_info;
+    fastcgi_param SCRIPT_FILENAME $request_filename;
   }
   
   # .htaccess file from Hubzilla converted using http://winginx.com/en/htaccess


### PR DESCRIPTION
Nginx gives error on reload if "/" is not present(the nginx will never load after reboot) .If " / " is added  nginx will give blank page . So this line need to be added to make it work again" fastcgi_param SCRIPT_FILENAME $request_filename;" .